### PR TITLE
feature(console): enable configuring test and oracle clusters

### DIFF
--- a/gemini_python/console.py
+++ b/gemini_python/console.py
@@ -1,9 +1,12 @@
+# pylint: disable=no-value-for-parameter
 import logging
 
 import click
 
 from gemini_python.executor import (
     CqlQueryExecutor,
+    NoOpQueryExecutor,
+    QueryExecutor,
 )
 from gemini_python.limiter import ConcurrencyLimiter
 from gemini_python.query import InsertQueryGenerator, SelectQueryGenerator
@@ -23,7 +26,20 @@ logging.getLogger().addHandler(logging.StreamHandler())
     default="read",
     help="Query operation mode",
 )
-def run(mode: str) -> None:
+@click.option(
+    "--oracle-cluster",
+    "-o",
+    type=str,
+    help="Comma separated host names or IPs of the oracle cluster that provides correct answers. If omitted no oracle will be used",
+)
+@click.option(
+    "--test-cluster",
+    "-t",
+    type=str,
+    required=True,
+    help="Comma separated host names or IPs of the test cluster that is system under test",
+)
+def run(mode: str, test_cluster: str, oracle_cluster: str) -> None:
     """Gemini is an automatic random testing tool for Scylla."""
     keyspace = generate_schema()
     match mode:
@@ -34,13 +50,17 @@ def run(mode: str) -> None:
         case _:
             raise ValueError("Not supported query operation mode")
 
-    sut_query_executor = CqlQueryExecutor(["192.168.100.3"])
-    oracle_query_executor = CqlQueryExecutor(["192.168.100.2"])
+    sut_query_executor = CqlQueryExecutor(test_cluster.split(","))
+    if oracle_cluster:
+        oracle_query_executor: QueryExecutor = CqlQueryExecutor(oracle_cluster.split(","))
+    else:
+        oracle_query_executor = NoOpQueryExecutor()
     for statement in keyspace.as_cql():
         sut_query_executor.execute(statement)
         oracle_query_executor.execute(statement)
     limiter = ConcurrencyLimiter(limit=20)
     validator = GeminiValidator(oracle=oracle_query_executor)
+
     run_gemini(
         generator=query,
         sut_executor=sut_query_executor,

--- a/gemini_python/executor.py
+++ b/gemini_python/executor.py
@@ -2,7 +2,7 @@
 import logging
 from abc import ABC
 from functools import lru_cache
-from typing import Callable, Iterable, Any
+from typing import Callable, Iterable
 
 from cassandra.cluster import Cluster, DCAwareRoundRobinPolicy  # type: ignore
 from cassandra.query import PreparedStatement  # type: ignore
@@ -11,28 +11,28 @@ logger = logging.getLogger(__name__)
 
 
 class QueryExecutor(ABC):
-    def __init__(self) -> None:
-        pass
+    """Responsible for communication with DB and running queries."""
 
     def execute_async(
         self,
         statement: str,
         query_values: tuple,
         on_success: list[Callable[[Iterable | None], None]],
-        on_error: list[Callable[[Any], None]],
+        on_error: list[Callable[[Exception], None]],
     ) -> None:
         """Execute statement asynchronously."""
 
-    def execute(self, statement: str, query_values: tuple) -> Iterable | None:
+    def execute(self, statement: str, query_values: tuple = ()) -> Iterable | None:
         """Executes statement synchronously."""
 
-    def prepare(self, statement: str) -> PreparedStatement:
+    def prepare(self, statement: str) -> None:
         """Preparation before running statement."""
 
 
 class CqlQueryExecutor(QueryExecutor):
+    """Communicates with and queries Scylla/Cassandra databases."""
+
     def __init__(self, hosts: list[str], port: int = 9042) -> None:
-        super().__init__()
         self.cluster = Cluster(
             hosts,
             port=port,
@@ -41,8 +41,11 @@ class CqlQueryExecutor(QueryExecutor):
         )
         self.session = self.cluster.connect()
 
+    def prepare(self, statement: str) -> None:
+        self._prepare_statement(statement)
+
     @lru_cache(maxsize=1000)
-    def prepare(self, statement: str) -> PreparedStatement:
+    def _prepare_statement(self, statement: str) -> PreparedStatement:
         """Prepare statement before running it. Cached so it is done only once."""
         return self.session.prepare(statement)
 
@@ -55,7 +58,7 @@ class CqlQueryExecutor(QueryExecutor):
     ) -> None:
         """Executes query statement with given values asynchronously
         and run callbacks on success/failure"""
-        prepared_statement = self.prepare(statement)
+        prepared_statement = self._prepare_statement(statement)
         # todo: execute_async of python driver somehow does not work
         #  - there's almost no benefit of concurrency
         future = self.session.execute_async(query=prepared_statement, parameters=query_values)
@@ -63,10 +66,14 @@ class CqlQueryExecutor(QueryExecutor):
             future.add_callback(callback)
         future.add_errback(on_error)
 
-    def execute(self, statement: str, query_values: tuple = ()) -> Iterable:
+    def execute(self, statement: str, query_values: tuple = ()) -> Iterable | None:
         """Executes statement synchronously."""
         return self.session.execute(statement, parameters=query_values)  # type: ignore
 
     def __del__(self) -> None:
         logger.info("Closing connection to %s", self.cluster.metadata.all_hosts())
         self.cluster.shutdown()
+
+
+class NoOpQueryExecutor(QueryExecutor):
+    """Does nothing. Used when no oracle is configured."""

--- a/gemini_python/limiter.py
+++ b/gemini_python/limiter.py
@@ -11,7 +11,7 @@ class Limiter(ABC):
         """Increments value. In case limit was reached,
         waits until value drops below limit."""
 
-    def decrement(self, _: Iterable | None = None) -> None:
+    def decrement(self, _: Iterable | Exception | None = None) -> None:
         """Decreases value.
         This lets increment method to proceed in case of waiting for value drop."""
 
@@ -36,7 +36,7 @@ class ConcurrencyLimiter(Limiter):
         except queue.Full as exc:
             raise TimeoutError("Timeout during waiting for async executor.") from exc
 
-    def decrement(self, _: Iterable | None = None) -> None:
+    def decrement(self, _: Iterable | Exception | None = None) -> None:
         """Decrements running async executions counter."""
         self._queue.get(block=False)
 

--- a/gemini_python/query.py
+++ b/gemini_python/query.py
@@ -4,6 +4,8 @@ from gemini_python.schema import Table
 
 
 class QueryGenerator(ABC):
+    """Base class for CQL queries generators."""
+
     def __init__(self, table: Table) -> None:
         self._table = table
 
@@ -15,6 +17,8 @@ class QueryGenerator(ABC):
 
 
 class InsertQueryGenerator(QueryGenerator):
+    """Basic insert query with all table columns."""
+
     def __init__(self, table: Table) -> None:
         super().__init__(table)
         self._stmt = (
@@ -33,6 +37,8 @@ class InsertQueryGenerator(QueryGenerator):
 
 
 class SelectQueryGenerator(QueryGenerator):
+    """Basic select query with all table columns."""
+
     def __init__(self, table: Table) -> None:
         super().__init__(table)
         self._stmt = (

--- a/gemini_python/schema.py
+++ b/gemini_python/schema.py
@@ -6,6 +6,8 @@ from gemini_python.column_types import Column, AsciiColumn, BigIntColumn
 
 @dataclass
 class Table:
+    """Represents Scylla table"""
+
     name: str
     keyspace_name: str
     primary_keys: List[Column]
@@ -31,13 +33,17 @@ class Table:
 
 @dataclass
 class Keyspace:
+    """Represents Scylla keyspace"""
+
     name: str
     replication_strategy: str
     tables: list[Table]
 
     def as_cql(self) -> list[str]:
-        statements = [f"CREATE KEYSPACE IF NOT EXISTS {self.name} "
-                      f"with replication = {self.replication_strategy};"]
+        statements = [
+            f"CREATE KEYSPACE IF NOT EXISTS {self.name} "
+            f"with replication = {self.replication_strategy};"
+        ]
         for table in self.tables:
             statements.append(table.as_cql())
         return statements

--- a/gemini_python/validator.py
+++ b/gemini_python/validator.py
@@ -6,6 +6,8 @@ from gemini_python.executor import QueryExecutor, logger
 
 
 class GeminiValidator:
+    """Class responsible for querying oracle and verifying returned results."""
+
     def __init__(self, oracle: QueryExecutor):
         self.oracle = oracle
 

--- a/gemini_python/worker.py
+++ b/gemini_python/worker.py
@@ -9,6 +9,10 @@ from gemini_python.validator import GeminiValidator
 logger = logging.getLogger(__name__)
 
 
+def handle_exception(exception: Exception) -> None:
+    logger.error(exception)
+
+
 def run_gemini(
     generator: QueryGenerator,
     sut_executor: QueryExecutor,
@@ -24,7 +28,7 @@ def run_gemini(
             statement,
             query_values,
             on_success=[limiter.decrement, validate_results],
-            on_error=[limiter.decrement, logger.error],
+            on_error=[limiter.decrement, handle_exception],
         )
     while limiter.value:
         # wait until all requests complete

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,13 @@ build-backend = "poetry.core.masonry.api"
 [tool.black]
 line-length = 100
 
+[tool.pylint.'MESSAGES CONTROL']
+disable = "missing-module-docstring, missing-function-docstring, fixme"
+
+[tool.pylint.'FORMAT']
+# black formats anyway to 100, but not long strings. For these allow len of 140.
+max-line-length=140
+
 [tool.mypy]
 python_version = "3.10"
 strict = true


### PR DESCRIPTION
This commit enables configuring test and oracle cluster from commandline. In case oracle is not provided, skip verification.

+ some fixes for pylint/mypy